### PR TITLE
Stop filtering magics

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,7 +43,10 @@ jobs:
           else
             test -f setup.py && pip install -e ".[dev]"
           fi
+      - name: Build Docs
+        run: |
           python nbdev_preview.py
+          
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,19 +3,54 @@ on:
   push:
     branches: [master]
   workflow_dispatch:
+
+env:
+  PYTHON_VERSION: 3.8
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/checkout@v3
+        
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-        
-      - uses: fastai/workflows/quarto-ghp@master
+          cache: "pip"
+          cache-dependency-path: settings.ini
+
+      - name: Install Dependencies
+        env:
+          USE_PRE: ''
+          TORCH_CPU: true
+        shell: bash
+        run: |
+          set -ux
+          python -m pip install --upgrade pip
+          if [ $USE_PRE ]; then
+            pip install -Uq git+https://github.com/fastai/ghapi.git
+            pip install -Uq git+https://github.com/fastai/fastcore.git
+            pip install -Uq git+https://github.com/fastai/execnb.git
+            pip install -Uq git+https://github.com/fastai/nbdev.git
+            wget -q $(curl https://latest.fast.ai/pre/quarto-dev/quarto-cli/linux-amd64.deb)
+            sudo dpkg -i quarto*.deb
+          else
+            pip install -Uq nbdev
+          fi
+          if [ $TORCH_CPU ]; then
+            test -f setup.py && pip install -e ".[dev]" --extra-index-url https://download.pytorch.org/whl/cpu
+          else
+            test -f setup.py && pip install -e ".[dev]"
+          fi
+          python nbdev_preview.py
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          # The python version that nbdev ci must run on must match the python version used 
-          version: ${{ env.PYTHON_VERSION }}
+          github_token: ${{ github.token }}
+          force_orphan: true
+          publish_dir: ./_docs
+          # The following lines assign commit authorship to the official GH-Actions bot for deploys to `gh-pages` branch.
+          # You can swap them out with your own user credentials.
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com

--- a/nbdev_preview.py
+++ b/nbdev_preview.py
@@ -2,7 +2,7 @@ import inspect
 from nbdev.processors import FilterDefaults
 from nbdev.quarto import nbdev_docs
 
-new_FilterDefaults = """
+monkey_patch_procs = """
 all_procs = FilterDefaults().procs()
 def new_procs(self):
     procs = [proc for proc in all_procs if proc.__name__ != 'clean_magics']
@@ -14,6 +14,6 @@ if __name__ == '__main__':
     module_file_path = inspect.getfile(FilterDefaults)
 
     with open(module_file_path, 'a') as f:
-        f.write(new_FilterDefaults)
+        f.write(monkey_patch_procs)
 
     nbdev_docs()

--- a/nbdev_preview.py
+++ b/nbdev_preview.py
@@ -3,6 +3,7 @@ from nbdev.processors import FilterDefaults
 from nbdev.quarto import nbdev_docs
 
 monkey_patch_procs = """
+# already_appended_marker
 all_procs = FilterDefaults().procs()
 def new_procs(self):
     procs = [proc for proc in all_procs if proc.__name__ != 'clean_magics']
@@ -10,10 +11,26 @@ def new_procs(self):
 FilterDefaults.procs = new_procs
 """
 
+def check_appeneded_marker(file_path # Path to nbdev.processors.py file
+                           ) -> bool: # True if we already appended new_procs, False otherwise
+    try:
+        with open(file_path, 'r') as file:
+            lines = file.readlines()
+
+            for line in lines:
+                if 'already_appended_marker' in line:
+                    return True
+            return False
+
+    except FileNotFoundError:
+        print(f"File {file_path} not found!")
+
 if __name__ == '__main__':
     module_file_path = inspect.getfile(FilterDefaults)
-
-    with open(module_file_path, 'a') as f:
-        f.write(monkey_patch_procs)
+    
+    # Check if we already appended new_procs
+    if not check_appeneded_marker(module_file_path):
+        with open(module_file_path, 'a') as f:
+            f.write(monkey_patch_procs)
 
     nbdev_docs()

--- a/nbdev_preview.py
+++ b/nbdev_preview.py
@@ -1,0 +1,19 @@
+import inspect
+from nbdev.processors import FilterDefaults
+from nbdev.quarto import nbdev_docs
+
+new_FilterDefaults = """
+all_procs = FilterDefaults().procs()
+def new_procs(self):
+    procs = [proc for proc in all_procs if proc.__name__ != 'clean_magics']
+    return procs
+FilterDefaults.procs = new_procs
+"""
+
+if __name__ == '__main__':
+    module_file_path = inspect.getfile(FilterDefaults)
+
+    with open(module_file_path, 'a') as f:
+        f.write(new_FilterDefaults)
+
+    nbdev_docs()


### PR DESCRIPTION
It turned out that the solution we did together did not actually work, even though it seemed to be.
We thought it worked because show_docs actually has some sort of a cache (_procs folder) that saved the HTML files that i got after i manually deleted "clean_magics" and ran nbdev_preview before the meeting to verify that this solves the problem.

this PR implements the same idea that we did but instead monkey patches the updated function inside the nbdev.processors file itself.